### PR TITLE
Selector matching syntax update, closes issue #4

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,3 +1,7 @@
 # How to run tests #
 
 In the source directory install the npm deps by typing `npm install`. Then load `tests/index.html` in a browser.
+
+# How to compile #
+
+See [http://www.typescriptlang.org/](http://www.typescriptlang.org/)

--- a/bower.json
+++ b/bower.json
@@ -17,8 +17,12 @@
   ],
   "license": "Apache 2.0",
   "ignore": [
-    "node_modules",
-    "tests"
+    "node_modules/",
+    "tests/"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/brucek/mutation-summary.git"
+  },
   "private": true
 }

--- a/bower.json
+++ b/bower.json
@@ -17,8 +17,11 @@
   ],
   "license": "Apache 2.0",
   "ignore": [
+    "docs/",
+    "examples/",
     "node_modules/",
-    "tests/"
+    "tests/",
+    "util/"
   ],
   "repository": {
     "type": "git",

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "brucek-mutation-summary",
+  "description": "Makes observing the DOM fast and easy",
+  "main": [
+    "src/mutation-summary.js"
+  ],
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "dom",
+    "mutation",
+    "observer"
+  ],
+  "authors": [
+    ""
+  ],
+  "license": "Apache 2.0",
+  "ignore": [
+    "node_modules",
+    "tests"
+  ],
+  "private": true
+}

--- a/src/mutation-summary.ts
+++ b/src/mutation-summary.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+declare var WebKitMutationObserver: any;
+
 var MutationObserverCtor;
 if (typeof WebKitMutationObserver !== 'undefined')
   MutationObserverCtor = WebKitMutationObserver;

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 function assertSelectorNames(selectors, expectSelectorStrings) {
-  assert.strictEqual(expectSelectorStrings.length, selectors.length);
+  assert.strictEqual(selectors.length, expectSelectorStrings.length);
   expectSelectorStrings.forEach(function(expectSelectorString, i) {
-    assert.strictEqual(expectSelectorString, selectors[i].selectorString);
+    assert.strictEqual(selectors[i].selectorString, expectSelectorString);
   });
 }
 
@@ -256,10 +256,6 @@ suite('Setup', function() {
       MutationSummary.parseElementFilter('div[foo=bar baz]');
     });
 
-    assert.throws(function() {
-      MutationSummary.parseElementFilter('div[foo|=bar]');
-    });
-
     assertSelectorNames(
       MutationSummary.parseElementFilter('div[foo~=bar]'),
       ['div[foo~="bar"]']
@@ -276,6 +272,78 @@ suite('Setup', function() {
 
     assert.throws(function() {
       MutationSummary.parseElementFilter('div[foo~ =bar]');
+    });
+
+    assertSelectorNames(
+      MutationSummary.parseElementFilter('div[foo^=bar]'),
+      ['div[foo^="bar"]']
+    );
+
+    assertSelectorNames(
+      MutationSummary.parseElementFilter('div[foo^="bar  "]'),
+      ['div[foo^="bar  "]']
+    );
+
+    assert.throws(function() {
+      MutationSummary.parseElementFilter('div[foo^=]');
+    });
+
+    assert.throws(function() {
+      MutationSummary.parseElementFilter('div[foo^ =bar]');
+    });
+
+    assertSelectorNames(
+      MutationSummary.parseElementFilter('div[foo$=bar]'),
+      ['div[foo$="bar"]']
+    );
+
+    assertSelectorNames(
+      MutationSummary.parseElementFilter('div[foo$="bar  "]'),
+      ['div[foo$="bar  "]']
+    );
+
+    assert.throws(function() {
+      MutationSummary.parseElementFilter('div[foo$=]');
+    });
+
+    assert.throws(function() {
+      MutationSummary.parseElementFilter('div[foo$ =bar]');
+    });
+
+    assertSelectorNames(
+      MutationSummary.parseElementFilter('div[foo*=bar]'),
+      ['div[foo*="bar"]']
+    );
+
+    assertSelectorNames(
+      MutationSummary.parseElementFilter('div[foo*="bar  "]'),
+      ['div[foo*="bar  "]']
+    );
+
+    assert.throws(function() {
+      MutationSummary.parseElementFilter('div[foo*=]');
+    });
+
+    assert.throws(function() {
+      MutationSummary.parseElementFilter('div[foo* =bar]');
+    });
+
+    assertSelectorNames(
+      MutationSummary.parseElementFilter('div[foo|=bar]'),
+      ['div[foo|="bar"]']
+    );
+
+    assertSelectorNames(
+      MutationSummary.parseElementFilter('div[foo|="bar  "]'),
+      ['div[foo|="bar  "]']
+    );
+
+    assert.throws(function() {
+      MutationSummary.parseElementFilter('div[foo|=]');
+    });
+
+    assert.throws(function() {
+      MutationSummary.parseElementFilter('div[foo| =bar]');
     });
 
     assertSelectorNames(
@@ -317,7 +385,7 @@ suite('Setup', function() {
     // queries is required.
     assert.throws(function() {
       new MutationSummary({
-        callback: function() {},
+        callback: function() {}
       });
     });
 
@@ -434,7 +502,7 @@ suite('Setup', function() {
     assert.throws(function() {
       new MutationSummary({
         callback: function() {},
-        queries: [{ element: 'div[noTrailingBracket', }]
+        queries: [{ element: 'div[noTrailingBracket' }]
       });
     });
 

--- a/tests/test-validator.js
+++ b/tests/test-validator.js
@@ -37,7 +37,7 @@ MutationSummary.createQueryValidator = function(root, query) {
     function allValidator(summary, stayed, old, current) {
       summary.reordered.forEach(function(node) {
         var oldPreviousSiblingMap = old.get(summary.getOldParentNode(node));
-        assert.strictEqual(oldPreviousSiblingMap.get(node), summary.getOldPreviousSibling(node));
+        assert.strictEqual(summary.getOldPreviousSibling(node), oldPreviousSiblingMap.get(node));
       });
     }
 
@@ -61,7 +61,7 @@ MutationSummary.createQueryValidator = function(root, query) {
       compareNodeArrayIgnoreOrder(changed, summary.valueChanged);
 
       changed.forEach(function(node) {
-        assert.strictEqual(old.get(node), summary.getOldCharacterData(node));
+        assert.strictEqual(summary.getOldCharacterData(node), old.get(node));
       });
     }
 
@@ -85,7 +85,7 @@ MutationSummary.createQueryValidator = function(root, query) {
       compareNodeArrayIgnoreOrder(changed, summary.valueChanged);
 
       changed.forEach(function(node) {
-        assert.strictEqual(old.get(node), summary.getOldAttribute(node, query.attribute));
+        assert.strictEqual(summary.getOldAttribute(node, query.attribute), old.get(node));
       });
     }
 
@@ -160,7 +160,7 @@ MutationSummary.createQueryValidator = function(root, query) {
       });
 
       function checkOldParentNode(node) {
-        assert.strictEqual(old.get(node).parentNode, summary.getOldParentNode(node));
+        assert.strictEqual(summary.getOldParentNode(node), old.get(node).parentNode);
       }
 
       summary.removed.forEach(checkOldParentNode);

--- a/tests/test.js
+++ b/tests/test.js
@@ -3,7 +3,7 @@
 ///<reference path='../util/tree-mirror.ts'/>
 
 function compareNodeArrayIgnoreOrder(expected, actual) {
-    assert.strictEqual(expected.length, actual.length);
+    assert.strictEqual(actual.length, expected.length);
 
     var map = new MutationSummary.NodeMap();
     expected.forEach(function (node) {
@@ -77,7 +77,7 @@ suite('Mutation Summary', function () {
 
         if (options.oldPreviousSibling) {
             expect.removed.forEach(function (node, index) {
-                assert.strictEqual(expect.removedOldPreviousSibling[index], changed.getOldPreviousSibling(node));
+                assert.strictEqual(changed.getOldPreviousSibling(node), expect.removedOldPreviousSibling[index]);
             });
         }
 
@@ -88,7 +88,7 @@ suite('Mutation Summary', function () {
 
             if (options.oldPreviousSibling) {
                 expect.reparented.forEach(function (node, index) {
-                    assert.strictEqual(expect.reparentedOldPreviousSibling[index], changed.getOldPreviousSibling(node));
+                    assert.strictEqual(changed.getOldPreviousSibling(node), expect.reparentedOldPreviousSibling[index]);
                 });
             }
         } else {
@@ -101,7 +101,7 @@ suite('Mutation Summary', function () {
             compareNodeArrayIgnoreOrder(expect.reordered, changed.reordered);
 
             expect.reordered.forEach(function (node, index) {
-                assert.strictEqual(expect.reorderedOldPreviousSibling[index], changed.getOldPreviousSibling(node));
+                assert.strictEqual(changed.getOldPreviousSibling(node), expect.reorderedOldPreviousSibling[index]);
             });
         } else {
             assert.isUndefined(changed.reordered);
@@ -114,7 +114,7 @@ suite('Mutation Summary', function () {
             var getOldFunction = query.attribute ? 'getOldAttribute' : 'getOldCharacterData';
 
             expect.valueChanged.forEach(function (node, index) {
-                assert.strictEqual(expect.oldValues[index], changed[getOldFunction](node, query.attribute));
+                assert.strictEqual(changed[getOldFunction](node, query.attribute), expect.oldValues[index]);
             });
         } else {
             assert.isUndefined(changed.valueChanged);
@@ -123,12 +123,12 @@ suite('Mutation Summary', function () {
         // attributeChanged
         if (query.all || query.elementAttributes) {
             assert(typeof expect.attributeChanged == typeof changed.attributeChanged);
-            assert.strictEqual(Object.keys(expect.attributeChanged).length, Object.keys(changed.attributeChanged).length);
+            assert.strictEqual(Object.keys(changed.attributeChanged).length, Object.keys(expect.attributeChanged).length);
 
             Object.keys(expect.attributeChanged).forEach(function (attrName) {
                 compareNodeArrayIgnoreOrder(expect.attributeChanged[attrName], changed.attributeChanged[attrName]);
                 expect.attributeOldValue[attrName].forEach(function (attrOldValue, index) {
-                    assert.strictEqual(expect.attributeOldValue[attrName][index], changed.getOldAttribute(expect.attributeChanged[attrName][index], attrName));
+                    assert.strictEqual(changed.getOldAttribute(expect.attributeChanged[attrName][index], attrName), expect.attributeOldValue[attrName][index]);
                 });
             });
         } else {
@@ -354,7 +354,7 @@ suite('Mutation Summary', function () {
 
     test('Element Attribute Specified', function () {
         startObserving({
-            element: 'div[foo], A, *[bar], div[ baz = "bat"], span#foo[blow~=blarg]'
+            element: 'div[foo], A, *[bar], div[ baz = "bat"], span#foo[blow~=blarg], span[some^=thing], span[another$=.html], ' + 'span[splat*=atat], div[lang|=en]'
         });
 
         var div = document.createElement('div');
@@ -372,6 +372,18 @@ suite('Mutation Summary', function () {
         var p = document.createElement('P');
         testDiv.appendChild(p);
         p.setAttribute('baz', 'baz');
+        var span2 = document.createElement('span');
+        span2.setAttribute('some', 'not a thing');
+        div2.appendChild(span2);
+        var span3 = document.createElement('span');
+        span3.setAttribute('another', '.html at the front');
+        div3.appendChild(span3);
+        var span4 = document.createElement('span');
+        span4.setAttribute('splat', 'no at at');
+        p.appendChild(span4);
+        var div4 = document.createElement('div');
+        testDiv.appendChild(div4);
+        div4.setAttribute('lang', 'not-en-matching');
         assertSummary({
             added: [div]
         });
@@ -382,13 +394,18 @@ suite('Mutation Summary', function () {
         div3.setAttribute('baz', 'bat');
         span.id = 'foo';
         span.setAttribute('blow', 'blarg bloog');
+        span2.setAttribute('some', 'thinggood');
+        span3.setAttribute('another', 'this one ends in.html');
+        span4.setAttribute('splat', 'some-atat-thing');
+        div4.setAttribute('lang', 'en-yes');
         assertSummary({
-            added: [p, div3, span],
+            added: [p, div3, span, span2, span3, span4, div4],
             removed: [div]
         });
 
         div3.removeAttribute('baz');
         div3.setAttribute('baz', 'bat');
+        div4.setAttribute('lang', 'en');
         assertNothingReported();
     });
 
@@ -1002,14 +1019,14 @@ suite('Mutation Summary', function () {
                 count++;
 
                 if (count == 1) {
-                    assert.strictEqual(1, summary.added.length);
+                    assert.strictEqual(summary.added.length, 1);
                     div = testDiv.appendChild(document.createElement('div'));
                 } else if (count == 2) {
-                    assert.strictEqual(2, summary.added.length);
+                    assert.strictEqual(summary.added.length, 2);
                     div = testDiv.appendChild(document.createElement('div'));
                     summary1.disconnect();
                 } else if (count == 3) {
-                    assert.strictEqual(1, summary.added.length);
+                    assert.strictEqual(summary.added.length, 1);
                     summary1.disconnect();
                     async();
                 }
@@ -1024,14 +1041,14 @@ suite('Mutation Summary', function () {
                 count++;
 
                 if (count == 1) {
-                    assert.strictEqual(1, summary.added.length);
+                    assert.strictEqual(summary.added.length, 1);
                     div = testDiv.appendChild(document.createElement('div'));
                 } else if (count == 2) {
-                    assert.strictEqual(2, summary.added.length);
+                    assert.strictEqual(summary.added.length, 2);
                     div = testDiv.appendChild(document.createElement('div'));
                     summary2.disconnect();
                 } else if (count == 3) {
-                    assert.strictEqual(1, summary.added.length);
+                    assert.strictEqual(summary.added.length, 1);
                     summary2.disconnect();
                     async();
                 }
@@ -1057,7 +1074,7 @@ suite('Mutation Summary', function () {
                 setTimeout(function () {
                     div.setAttribute('bar', 'baz');
                     setTimeout(function () {
-                        assert.strictEqual(1, callbackCount);
+                        assert.strictEqual(callbackCount, 1);
                         async();
                     });
                 }, 0);
@@ -1148,21 +1165,21 @@ suite('TreeMirror Fuzzer', function () {
     }
 
     function assertTreesEqual(node, copy) {
-        assert.strictEqual(node.tagName, copy.tagName);
-        assert.strictEqual(node.id, copy.id);
+        assert.strictEqual(copy.tagName, node.tagName);
+        assert.strictEqual(copy.id, node.id);
 
-        assert.strictEqual(node.nodeType, copy.nodeType);
+        assert.strictEqual(copy.nodeType, node.nodeType);
         if (node.nodeType == Node.ELEMENT_NODE) {
-            assert.strictEqual(node.attributes.length, copy.attributes.length);
+            assert.strictEqual(copy.attributes.length, node.attributes.length);
             for (var i = 0; i < node.attributes.length; i++) {
                 var attr = node.attributes[i];
-                assert.strictEqual(attr.value, copy.getAttribute(attr.name));
+                assert.strictEqual(copy.getAttribute(attr.name), attr.value);
             }
         } else {
-            assert.strictEqual(node.textContent, copy.textContent);
+            assert.strictEqual(copy.textContent, node.textContent);
         }
 
-        assert.strictEqual(node.childNodes.length, copy.childNodes.length);
+        assert.strictEqual(copy.childNodes.length, node.childNodes.length);
 
         var copyChild = copy.firstChild;
         for (var child = node.firstChild; child; child = child.nextSibling) {


### PR DESCRIPTION
Included some minor code cleanup and reordering test assertion arguments so error messages make more sense
Closes [Implement attribute start matching, ie [foo^=bar]](https://github.com/rafaelw/mutation-summary/issues/4)
