### PR TITLE
Remove return statement which causes page not loading.

### DIFF
--- a/examples/pagemirror_extension/content_script.js
+++ b/examples/pagemirror_extension/content_script.js
@@ -17,7 +17,6 @@ var observer;
 if (typeof WebKitMutationObserver != 'function') {
   console.error('This example extension requires MutationObservers. ' +
                 'Try the Chrome Canary build.');
-  return;
 }
 
 chrome.extension.onConnect.addListener(function(port) {


### PR DESCRIPTION
The original tab gives "Uncaught SyntaxError: Illegal return statement" error and new tab won't load.
